### PR TITLE
Remove quotes around "dialyzer" to fix elixir 1.7 errors

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule ParamsNormalizer.Mixfile do
 
   defp aliases do
     [
-      "dialyzer": ["dialyzer -Wno_return"]
+      dialyzer: ["dialyzer -Wno_return"]
     ]
 end
 end


### PR DESCRIPTION
Small PR to update this dependency for kickback-api & others. Wrapping atoms in quotes now throws a warning in 1.7, causing buildkite pipelines to fail